### PR TITLE
Adds support for Rails 6 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/coverage
 /tmp
 /*.cache
 /config.yaml
@@ -9,6 +10,7 @@
 /vendor/specifications
 /.bundle
 .ruby-version
+.idea
 pkg
 log
 *.sqlite3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
+  - 2.6.3
 script:
   - export RAILS_ENV=test
   - bundle exec rake app:db:create app:db:setup
@@ -14,6 +15,7 @@ env:
   - DB=sqlite
   - DB=postgresql
 gemfile:
+  - gemfiles/Gemfile.rails-6.0-stable
   - gemfiles/Gemfile.rails-5.2-stable
   - gemfiles/Gemfile.rails-5.1-stable
   - gemfiles/Gemfile.rails-5.0-stable

--- a/gemfiles/Gemfile.rails-6.0-stable
+++ b/gemfiles/Gemfile.rails-6.0-stable
@@ -1,0 +1,17 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem "rails", '~> 6.0.0'
+gem "rack", "~> 2.0"
+
+case ENV['DB']
+when 'postgresql'
+  gem 'pg'
+when 'mysql'
+  gem 'mysql2', '~> 0.5.2'
+when 'sqlite'
+  gem 'sqlite3'
+else
+  gem 'sqlite3'
+end

--- a/lib/seed_migration.rb
+++ b/lib/seed_migration.rb
@@ -20,7 +20,7 @@ module SeedMigration
     end
 
     def unregister(model)
-      self.registrar.delete_if { |entry| entry.model == model }
+      self.registrar.delete_if { |entry| entry.model_name == model.to_s }
     end
   end
 end

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -285,7 +285,7 @@ SeedMigration::Migrator.bootstrap(#{last_migration})
 
       if Rails::VERSION::MAJOR == 3 || defined?(ActiveModel::MassAssignmentSecurity)
         model_creation_string = "#{instance.class}.#{create_method}(#{JSON.parse(sorted_attributes.to_json)}, :without_protection => true)"
-      elsif Rails::VERSION::MAJOR == 4 || Rails::VERSION::MAJOR == 5
+      elsif [4, 5, 6].include?(Rails::VERSION::MAJOR)
         model_creation_string = "#{instance.class}.#{create_method}(#{JSON.parse(sorted_attributes.to_json)})"
       end
 

--- a/lib/seed_migration/register_entry.rb
+++ b/lib/seed_migration/register_entry.rb
@@ -1,29 +1,31 @@
 module SeedMigration
   class RegisterEntry
-    attr_reader :model
-    attr_accessor :attributes
+    attr_reader :model_name
 
     def initialize(model)
-      @model = model
-      @attributes = model.attribute_names.dup
+      @model_name = model.to_s
+      @excluded_attributes = []
     end
 
     def exclude(*attrs)
-      attrs.map(&:to_s).each { |attr| exclude_single_attributes attr }
+      attrs.map(&:to_s).each { |attr| @excluded_attributes << attr }
+      @attributes = nil
     end
 
-    def eql?(object)
-      object.class == self.class && object.model == self.model
+    def eql?(other)
+      other.class == self.class && other.model_name == model_name
     end
 
     def hash
-      model.hash
+      model_name.hash
     end
 
-    private
+    def model
+      @model ||= Object.const_get(@model_name)
+    end
 
-    def exclude_single_attributes(attr)
-      @attributes.delete attr
+    def attributes
+      @attributes ||= model.attribute_names.reject { |attr| @excluded_attributes.include?(attr) }
     end
   end
 end

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -24,7 +24,7 @@ Dummy::Application.configure do
 
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
-  config.active_record.auto_explain_threshold_in_seconds = 0.5
+  # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   # Do not compress assets
   config.assets.compress = false

--- a/spec/lib/register_entry_spec.rb
+++ b/spec/lib/register_entry_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 describe SeedMigration::RegisterEntry do
   let(:entry) { SeedMigration::RegisterEntry.new(User) }
 
+  describe '#model' do
+    it 'builds from model name' do
+      entry = SeedMigration::RegisterEntry.new('User')
+      expect(entry.model).to eq User
+    end
+  end
+
   describe '#attributes' do
     it 'exists' do
       entry.attributes.should be_a_kind_of Array


### PR DESCRIPTION
Adds Rails 6 support.  Configuration now accepts registered model class as string and lazy loads model/attributes as required.  This fixes Rails 6 class auto-loader depreciation as well as fixes Rails 5.2  and later early schema load failures.  

So, for Rails 5.2 or later the configuration would look like:
```
SeedMigration.config do |c|
  c.register 'User' do
    exclude :some_field
  end
end
```