### PR TITLE
[ENG-34305] Disable transactions by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/coverage
 /tmp
 /*.cache
 /config.yaml
@@ -9,6 +10,7 @@
 /vendor/specifications
 /.bundle
 .ruby-version
+.idea
 pkg
 log
 *.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pkg
 log
 *.sqlite3
 seeds.rb
+/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
+  - 2.6.3
 script:
   - export RAILS_ENV=test
   - bundle exec rake app:db:create app:db:setup
@@ -14,6 +15,7 @@ env:
   - DB=sqlite
   - DB=postgresql
 gemfile:
+  - gemfiles/Gemfile.rails-6.0-stable
   - gemfiles/Gemfile.rails-5.2-stable
   - gemfiles/Gemfile.rails-5.1-stable
   - gemfiles/Gemfile.rails-5.0-stable

--- a/README.md
+++ b/README.md
@@ -210,14 +210,19 @@ end
 ## Disable Transactions
 
 Support has been added for disabling transactions for long running migrations.
+Since a long running migration can lock a table in production, transactions are
+disabled by default. You should always try to write idempotent migrations,
+but if you can't, you can either add transaction blocks manually in your migration,
+or if you just want to enable a transaction around the whole migration, you can
+call `use_transaction!`.
 
 ```ruby
 class ChangeABunchOfJobs < SeedMigration::Migration
 
-  disable_transaction!
+  use_transaction!
 
   def up
-    Job.all.in_batches.update_all(awesome: true)
+    ...
   end
 
   def down

--- a/README.md
+++ b/README.md
@@ -207,6 +207,25 @@ class AddADummyProduct < SeedMigration::Migration
 end
 ```
 
+## Disable Transactions
+
+Support has been added for disabling transactions for long running migrations.
+
+```ruby
+class ChangeABunchOfJobs < SeedMigration::Migration
+
+  disable_transaction!
+
+  def up
+    Job.all.in_batches.update_all(awesome: true)
+  end
+
+  def down
+  end
+
+end
+```
+
 ## Configuration
 
 Use an initializer file for configuration.

--- a/gemfiles/Gemfile.rails-6.0-stable
+++ b/gemfiles/Gemfile.rails-6.0-stable
@@ -1,0 +1,17 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem "rails", '~> 6.0.0'
+gem "rack", "~> 2.0"
+
+case ENV['DB']
+when 'postgresql'
+  gem 'pg'
+when 'mysql'
+  gem 'mysql2', '~> 0.5.2'
+when 'sqlite'
+  gem 'sqlite3'
+else
+  gem 'sqlite3'
+end

--- a/lib/seed_migration.rb
+++ b/lib/seed_migration.rb
@@ -20,7 +20,7 @@ module SeedMigration
     end
 
     def unregister(model)
-      self.registrar.delete_if { |entry| entry.model == model }
+      self.registrar.delete_if { |entry| entry.model_name == model.to_s }
     end
   end
 end

--- a/lib/seed_migration/engine.rb
+++ b/lib/seed_migration/engine.rb
@@ -10,7 +10,7 @@ module SeedMigration
   mattr_accessor :update_seeds_file
   mattr_accessor :migrations_path
   mattr_accessor :use_strict_create
-  mattr_accessor :use_activerecord_import
+  mattr_accessor :use_activerecord_bulk_insert
 
   self.migration_table_name = DEFAULT_TABLE_NAME
   self.extend_native_migration_task = false
@@ -18,7 +18,7 @@ module SeedMigration
   self.update_seeds_file = true
   self.migrations_path = 'data'
   self.use_strict_create = false
-  self.use_activerecord_import = false
+  self.use_activerecord_bulk_insert = false
 
   def self.config
     yield self
@@ -35,8 +35,8 @@ module SeedMigration
     use_strict_create
   end
 
-  def self.use_activerecord_import?
-    use_activerecord_import
+  def self.use_activerecord_bulk_insert?
+    use_activerecord_bulk_insert
   end
 
   class Engine < ::Rails::Engine

--- a/lib/seed_migration/engine.rb
+++ b/lib/seed_migration/engine.rb
@@ -4,6 +4,14 @@ module SeedMigration
 
   DEFAULT_TABLE_NAME = 'seed_migration_data_migrations'
 
+  # Default environments list set, defaults to []
+  mattr_accessor :environments_defaults
+  # set the current enviroment rails value, defaults to Rails.env
+  mattr_accessor :environments_rails_value
+  # set if the environments method should explicitly be called in the seeds, defaults to false
+  mattr_accessor :environments_required
+  # set the seed version from where the environments check should start, defaults to nil (which will check it from the first seed file)
+  mattr_accessor :environments_version_bootstrap
   mattr_accessor :extend_native_migration_task
   mattr_accessor :migration_table_name
   mattr_accessor :ignore_ids
@@ -12,6 +20,10 @@ module SeedMigration
   mattr_accessor :use_strict_create
   mattr_accessor :use_activerecord_bulk_insert
 
+  self.environments_defaults = []
+  self.environments_rails_value = Rails.env
+  self.environments_required = false
+  self.environments_version_bootstrap = nil
   self.migration_table_name = DEFAULT_TABLE_NAME
   self.extend_native_migration_task = false
   self.ignore_ids = false
@@ -37,6 +49,10 @@ module SeedMigration
 
   def self.use_activerecord_bulk_insert?
     use_activerecord_bulk_insert
+  end
+
+  def self.environments_required?
+    environments_required
   end
 
   class Engine < ::Rails::Engine

--- a/lib/seed_migration/engine.rb
+++ b/lib/seed_migration/engine.rb
@@ -10,6 +10,7 @@ module SeedMigration
   mattr_accessor :update_seeds_file
   mattr_accessor :migrations_path
   mattr_accessor :use_strict_create
+  mattr_accessor :use_activerecord_import
 
   self.migration_table_name = DEFAULT_TABLE_NAME
   self.extend_native_migration_task = false
@@ -17,6 +18,7 @@ module SeedMigration
   self.update_seeds_file = true
   self.migrations_path = 'data'
   self.use_strict_create = false
+  self.use_activerecord_import = false
 
   def self.config
     yield self
@@ -31,6 +33,10 @@ module SeedMigration
 
   def self.use_strict_create?
     use_strict_create
+  end
+
+  def self.use_activerecord_import?
+    use_activerecord_import
   end
 
   class Engine < ::Rails::Engine

--- a/lib/seed_migration/environments.rb
+++ b/lib/seed_migration/environments.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#
+# Define instance and class methods to manage migration environments
+# on the seed migration files
+#
+# This module is included by SeedMigration::Migration, so its
+# methods are available to all seed migration files.
+#
+module Environments
+  # Class methods
+  module ClassMethods
+    attr_reader :environment_names_array
+
+    # Define environments to apply the seed migration
+    #
+    # class MyMigration < SeedMigration::Migration
+    #
+    #   environments :production-us, :production-eu
+    #
+    #   def up
+    #   end
+    #
+    #   def down
+    #   end
+    # end
+    #
+    def environments(*environment_names)
+      @environment_names_array = environment_names
+    end
+  end
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+end

--- a/lib/seed_migration/migration.rb
+++ b/lib/seed_migration/migration.rb
@@ -7,17 +7,18 @@ module SeedMigration
     include Environments
 
     class << self
-      attr_accessor :transaction_disabled
+      attr_accessor :transaction_enabled
+
       # Disable the transaction wrapping this migration.
       # You can still create your own transactions even after
       # calling #disable_transaction!
-      def disable_transaction!
-        @transaction_disabled = true
+      def use!
+        @transaction_enabled = true
       end
     end
 
-    def transaction_disabled?
-      self.class.transaction_disabled
+    def transaction_enabled?
+      self.class.transaction_enabled
     end
 
     def up

--- a/lib/seed_migration/migration.rb
+++ b/lib/seed_migration/migration.rb
@@ -6,6 +6,20 @@ module SeedMigration
   class Migration
     include Environments
 
+    class << self
+      attr_accessor :transaction_disabled
+      # Disable the transaction wrapping this migration.
+      # You can still create your own transactions even after
+      # calling #disable_transaction!
+      def disable_transaction!
+        @transaction_disabled = true
+      end
+    end
+
+    def transaction_disabled?
+      self.class.transaction_disabled
+    end
+
     def up
       raise NotImplementedError
     end

--- a/lib/seed_migration/migration.rb
+++ b/lib/seed_migration/migration.rb
@@ -1,5 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'environments'
+
 module SeedMigration
   class Migration
+    include Environments
+
     def up
       raise NotImplementedError
     end

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -298,7 +298,7 @@ SeedMigration::Migrator.bootstrap(#{last_migration})
         model_creation_string = "  #{JSON.parse(sorted_attributes.to_json)},"
       elsif Rails::VERSION::MAJOR == 3 || defined?(ActiveModel::MassAssignmentSecurity)
         model_creation_string = "#{instance.class}.#{create_method}(#{JSON.parse(sorted_attributes.to_json)}, :without_protection => true)"
-      elsif Rails::VERSION::MAJOR == 4 || Rails::VERSION::MAJOR == 5
+      elsif [4, 5, 6].include?(Rails::VERSION::MAJOR)
         model_creation_string = "#{instance.class}.#{create_method}(#{JSON.parse(sorted_attributes.to_json)})"
       end
 

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -90,12 +90,12 @@ module SeedMigration
     end
 
     def transaction(klass)
-      if transaction_disabled?
-        yield
-      else
+      if transaction_enabled
         ActiveRecord::Base.transaction do
           yield
         end
+      else
+        yield
       end
     end
 

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -27,7 +27,7 @@ module SeedMigration
 
       start_time = Time.now
       announce("#{klass}: migrating")
-      ActiveRecord::Base.transaction do
+      transaction(klass) do
         if should_apply_in_this_environment?(klass, version)
           klass.new.up
         else
@@ -68,7 +68,7 @@ module SeedMigration
       # Revert
       start_time = Time.now
       announce("#{klass}: reverting")
-      ActiveRecord::Base.transaction do
+      transaction(klass) do
         if should_apply_in_this_environment?(klass, version)
           klass.new.down
         else
@@ -85,6 +85,16 @@ module SeedMigration
           announce("#{klass}: reverted (#{runtime}s)")
         else
           announce("#{klass}: version reverted just for rollback consistency (#{runtime}s)")
+        end
+      end
+    end
+
+    def transaction(klass)
+      if transaction_disabled?
+        yield
+      else
+        ActiveRecord::Base.transaction do
+          yield
         end
       end
     end

--- a/lib/seed_migration/register_entry.rb
+++ b/lib/seed_migration/register_entry.rb
@@ -1,29 +1,31 @@
 module SeedMigration
   class RegisterEntry
-    attr_reader :model
-    attr_accessor :attributes
+    attr_reader :model_name
 
     def initialize(model)
-      @model = model
-      @attributes = model.attribute_names.dup
+      @model_name = model.to_s
+      @excluded_attributes = []
     end
 
     def exclude(*attrs)
-      attrs.map(&:to_s).each { |attr| exclude_single_attributes attr }
+      attrs.map(&:to_s).each { |attr| @excluded_attributes << attr }
+      @attributes = nil
     end
 
-    def eql?(object)
-      object.class == self.class && object.model == self.model
+    def eql?(other)
+      other.class == self.class && other.model_name == model_name
     end
 
     def hash
-      model.hash
+      model_name.hash
     end
 
-    private
+    def model
+      @model ||= Object.const_get(@model_name)
+    end
 
-    def exclude_single_attributes(attr)
-      @attributes.delete attr
+    def attributes
+      @attributes ||= model.attribute_names.reject { |attr| @excluded_attributes.include?(attr) }
     end
   end
 end

--- a/lib/seed_migration/register_entry.rb
+++ b/lib/seed_migration/register_entry.rb
@@ -1,6 +1,6 @@
 module SeedMigration
   class RegisterEntry
-    attr_reader :model_name
+    attr_reader :model_name, :excluded_attributes
 
     def initialize(model)
       @model_name = model.to_s

--- a/lib/seed_migration/version.rb
+++ b/lib/seed_migration/version.rb
@@ -1,3 +1,3 @@
 module SeedMigration
-  VERSION = "1.2.3"
+  VERSION = "1.2.4-swoop-enhancements"
 end

--- a/lib/seed_migration/version.rb
+++ b/lib/seed_migration/version.rb
@@ -1,3 +1,3 @@
 module SeedMigration
-  VERSION = "1.2.4-swoop-enhancements"
+  VERSION = "1.2.5-swoop-enhancements"
 end

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -24,7 +24,7 @@ Dummy::Application.configure do
 
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
-  config.active_record.auto_explain_threshold_in_seconds = 0.5
+  # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   # Do not compress assets
   config.assets.compress = false

--- a/spec/lib/register_entry_spec.rb
+++ b/spec/lib/register_entry_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 describe SeedMigration::RegisterEntry do
   let(:entry) { SeedMigration::RegisterEntry.new(User) }
 
+  describe '#model' do
+    it 'builds from model name' do
+      entry = SeedMigration::RegisterEntry.new('User')
+      expect(entry.model).to eq User
+    end
+  end
+
   describe '#attributes' do
     it 'exists' do
       entry.attributes.should be_a_kind_of Array


### PR DESCRIPTION
We've had several incidences where the implicit transaction around a data migration locked a table in production for several minutes. We're removing this transaction by default since it's too easy to let these kinds of things slip through since the code gives no indication that it will do that unless you know the inner working of this gem.