### PR TITLE
Generate seeds for HABTM associations

### DIFF
--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -282,12 +282,15 @@ ActiveRecord::Base.transaction do
               next unless model_class_registered?(associated_class)
 
               instance.public_send(associated_class_sym).each do |associated_instance|
-                instance_association_string = "#{register_entry.model}.find(#{instance.id}).#{associated_class_sym}"
+                # e.g. Model1.find(#{id}).Model2
+                instance_association_string = "#{register_entry_model}.find(#{instance.id}).#{associated_class_sym}"
+                # e.g. Model2.find(#{id}), to be added to HABTM association
                 associated_instance_string = "#{associated_class}.find(#{associated_instance.id})"
-                check_for_existing_association_string = "#{instance_string}.pluck(:id).include?(#{associated_instance.id})"
+                # e.g. Model1.find(#{id}).model2s.pluck(:id).include?(#{associated_instance.id})
+                check_for_existing_association_string = "#{instance_association_string}.pluck(:id).include?(#{associated_instance.id})"
 
                 file.write <<-eos
-  "#{instance_string} << #{associated_instance_string} unless #{check_for_existing_association_string}"
+  "#{instance_association_string} << #{associated_instance_string} unless #{check_for_existing_association_string}"
                 eos
               end
             end

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -252,6 +252,15 @@ module SeedMigration
 #
 # It's strongly recommended to check this file into your version control system.
 
+# Ignore exceptions when appending to an HABTM association
+def safe_habtm_append(model_associations, associated_model_instance_arr)
+  begin
+    model_associations << associated_model_instance_arr
+  rescue ActiveRecord::RecordNotUnique => e
+
+  end
+end
+
 ActiveRecord::Base.transaction do
         eos
         SeedMigration.registrar.each do |register_entry|
@@ -270,7 +279,6 @@ ActiveRecord::Base.transaction do
         file.write <<-eos
 
   # HABTM Associations
-
         eos
         # Create list of unique HABTM associations
         habtm_associations_to_add = Set.new
@@ -289,8 +297,6 @@ ActiveRecord::Base.transaction do
             habtm_associations_to_add.add([registered_model_sym, associated_class_sym].sort)
           end
         end
-
-        puts "HABTM Set: #{habtm_associations_to_add.inspect}"
 
         # Handle HABTM associations
         habtm_associations_to_add.each do |associated_model_syms|
@@ -320,7 +326,7 @@ ActiveRecord::Base.transaction do
 
             file.write <<-eos
 
-  #{model_instance_association_string} << #{associated_model_instances_string}
+  safe_habtm_append(#{model_instance_association_string}, #{associated_model_instances_string})
             eos
           end
         end

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -255,7 +255,8 @@ module SeedMigration
 ActiveRecord::Base.transaction do
         eos
         SeedMigration.registrar.each do |register_entry|
-          register_entry.model.order('id').each do |instance|
+          model_records = register_entry.model_has_attribute?(:id) ? register_entry.model.order('id') : register_entry.model.all
+          model_records.each do |instance|
             file.write generate_model_creation_string(instance, register_entry)
           end
 

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -267,6 +267,11 @@ ActiveRecord::Base.transaction do
           end
         end
 
+        file.write <<-eos
+
+  # HABTM Associations
+
+        eos
         # Handle HABTM associations
         SeedMigration.registrar.each do |register_entry|
 

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -293,7 +293,8 @@ ActiveRecord::Base.transaction do
                 check_for_existing_association_string = "#{instance_association_string}.pluck(:id).include?(#{associated_instance.id})"
 
                 file.write <<-eos
-  "#{instance_association_string} << #{associated_instance_string} unless #{check_for_existing_association_string}"
+
+  #{instance_association_string} << #{associated_instance_string} unless #{check_for_existing_association_string}
                 eos
               end
             end

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -279,8 +279,8 @@ ActiveRecord::Base.transaction do
           model_habtm_associations = register_entry.model.reflect_on_all_associations(:has_and_belongs_to_many)
 
           model_habtm_associations.each do |association|
-            associated_class_sym = association.name
-            associated_class = associated_class_sym.to_s.classify.constantize
+            associated_class_sym = association.plural_name.singularize.to_sym
+            associated_class = association.plural_name.classify.constantize
 
             # If the associated model is not registered, don't populate join table
             next unless model_class_registered?(associated_class)
@@ -290,7 +290,7 @@ ActiveRecord::Base.transaction do
           end
         end
 
-        puts habtm_associations_to_add.inspect
+        puts "HABTM Set: #{habtm_associations_to_add.inspect}"
 
         # Handle HABTM associations
         SeedMigration.registrar.each do |register_entry|

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -257,7 +257,7 @@ def safe_habtm_append(model_associations, associated_model_instance_arr)
   begin
     model_associations << associated_model_instance_arr
   rescue ActiveRecord::RecordNotUnique => e
-
+    SeedMigration::Migrator.logger.error e
   end
 end
 

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -293,7 +293,7 @@ ActiveRecord::Base.transaction do
         puts "HABTM Set: #{habtm_associations_to_add.inspect}"
 
         # Handle HABTM associations
-        habtm_associations_to_add do |associated_model_syms|
+        habtm_associations_to_add.each do |associated_model_syms|
           model_sym = associated_model_syms.first
           model = model_sym.to_s.classify.constantize
 

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -269,6 +269,7 @@ ActiveRecord::Base.transaction do
 
         # Handle HABTM associations
         SeedMigration.registrar.each do |register_entry|
+
           # Get all HABTM associations for register_entry model
           habtm_associations = register_entry.model.reflect_on_all_associations(:has_and_belongs_to_many)
           next unless habtm_associations.present?
@@ -279,11 +280,13 @@ ActiveRecord::Base.transaction do
               # Get all entries in join table
               associated_class_sym = association.name
               associated_class = associated_class_sym.to_s.classify.constantize
+
+              # If the associated model is not registered, don't populate join table
               next unless model_class_registered?(associated_class)
 
               instance.public_send(associated_class_sym).each do |associated_instance|
                 # e.g. Model1.find(#{id}).Model2
-                instance_association_string = "#{register_entry_model}.find(#{instance.id}).#{associated_class_sym}"
+                instance_association_string = "#{register_entry.model}.find(#{instance.id}).#{associated_class_sym}"
                 # e.g. Model2.find(#{id}), to be added to HABTM association
                 associated_instance_string = "#{associated_class}.find(#{associated_instance.id})"
                 # e.g. Model1.find(#{id}).model2s.pluck(:id).include?(#{associated_instance.id})

--- a/lib/seed_migration/register_entry.rb
+++ b/lib/seed_migration/register_entry.rb
@@ -27,5 +27,9 @@ module SeedMigration
     def attributes
       @attributes ||= model.attribute_names.reject { |attr| @excluded_attributes.include?(attr) }
     end
+
+    def model_has_attribute?(attr)
+      model.attribute_names.include?(attr.to_s)
+    end
   end
 end


### PR DESCRIPTION
This PR addresses #34.  The change add seeds for  join tables for an HABTM association by iterating over all HABTM associations in a model.  